### PR TITLE
Moving pageIndexNotifier.addListener from initState to a separated method

### DIFF
--- a/lib/page_view_indicator.dart
+++ b/lib/page_view_indicator.dart
@@ -62,7 +62,9 @@ class _PageViewIndicatorState extends State<PageViewIndicator>
 
     _indicators[widget.currentPage].normalController.reverse();
     _indicators[widget.currentPage].highlightedController.forward();
+  }
 
+  _addIndicatorsListener() {
     widget.pageIndexNotifier.addListener(() {
       final currPage = widget.pageIndexNotifier.value;
 
@@ -86,6 +88,7 @@ class _PageViewIndicatorState extends State<PageViewIndicator>
 
   @override
   Widget build(BuildContext context) {
+    _addIndicatorsListener();
     return Row(
       mainAxisAlignment: widget.alignment,
       children: _indicators


### PR DESCRIPTION
The pageIndexNotifier.addListener was being invoked in initState but initState is called only once in the widget's life cycle so when you navigated from one screen to another the indicator stops working. I moved the call to a method that is called in build.