### PR TITLE
Fix indicator unmark issue when currentPage is different than 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.1
+* Fix indicator unmark issue when currentPage is different than 0
+
 # 2.0.0
 * Passes the indicator index on the builders
 * Fixes some bugs

--- a/lib/page_view_indicator.dart
+++ b/lib/page_view_indicator.dart
@@ -3,6 +3,7 @@ library page_view_indicator;
 
 import 'package:flutter/material.dart';
 import 'package:page_view_indicator/src/indicator.dart';
+import 'dart:math';
 
 export 'src/circle.dart';
 
@@ -42,12 +43,13 @@ class PageViewIndicator extends StatefulWidget {
 class _PageViewIndicatorState extends State<PageViewIndicator>
     with TickerProviderStateMixin {
   List<Indicator> _indicators;
-  int _prevPage = 0;
+  int _prevPage;
 
   @override
   void initState() {
     super.initState();
-
+    _prevPage = max(0, widget.currentPage);
+    
     _indicators = List.generate(
         widget.length,
         (index) => Indicator(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: page_view_indicator
-version: 2.0.0
+version: 2.0.1
 description: Builds indication marks for PageView from any Widget and/or Animation.
 author: leocavalcante <lc@leocavalcante.com>
 homepage: https://github.com/leocavalcante/page_view_indicator


### PR DESCRIPTION
There was a bug with marking the previous page as normal if currentPage was different than 0.
e.g:
CurrentPage is (5)
PageIndexNotifier is (5)

After changing page from 5 to 6 listener will invoke and it will mark _prevPage indicator as normal but _prevPage was 0, not 5.
