### PR TITLE
Ensure ValueNotifier never notifies twice

### DIFF
--- a/lib/page_view_indicator.dart
+++ b/lib/page_view_indicator.dart
@@ -61,6 +61,7 @@ class _PageViewIndicatorState extends State<PageViewIndicator>
   }
 
   void _addIndicatorsListener() {
+    widget.pageIndexNotifier.removeListener(_indicatorsListener);
     widget.pageIndexNotifier.addListener(_indicatorsListener);
   }
 


### PR DESCRIPTION
Hi,
This tiny fix is about do not add `_indicatorsListener()` twice even if `didUpdateWidget()` is called.
Closes #16 

Regards:
Janos Roden